### PR TITLE
Standardize terraform-docs config and cleanup atlantis

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Run `gh auth login` to authenticate with Github.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.7 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.12.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.8 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | 6.13.0 |
 | <a name="requirement_sops"></a> [sops](#requirement\_sops) | 1.4.1 |
 
 ### Providers

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -4,7 +4,6 @@ automerge: true
 delete_source_branch_on_merge: true
 projects:
   - name: terraform-github
-    # terraform_version: v1.10.5
     dir: .
     autoplan:
       when_modified: ["*.tf", "**/*.tf", "secrets.sops.yaml"]


### PR DESCRIPTION
- Standardize `.terraform-docs.yaml` to minimal format (flat repos: indent 3)
- Remove commented-out `terraform_version` from `atlantis.yaml`
- Regenerated READMEs via terraform-docs